### PR TITLE
fixed double balance call issue

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,21 +1,21 @@
-altgraph @ file:///AppleInternal/Library/BuildRoots/2c89a47b-9dd5-11ef-938f-6e654a286000/Library/Caches/com.apple.xbs/Sources/python3/altgraph-0.17.2-py2.py3-none-any.whl
+# altgraph @ file:///AppleInternal/Library/BuildRoots/2c89a47b-9dd5-11ef-938f-6e654a286000/Library/Caches/com.apple.xbs/Sources/python3/altgraph-0.17.2-py2.py3-none-any.whl
 blinker==1.9.0
 click==8.1.7
 exceptiongroup==1.2.2
 Flask==3.1.0
 Flask-Cors==5.0.0
-future @ file:///AppleInternal/Library/BuildRoots/2c89a47b-9dd5-11ef-938f-6e654a286000/Library/Caches/com.apple.xbs/Sources/python3/future-0.18.2-py3-none-any.whl
+# future @ file:///AppleInternal/Library/BuildRoots/2c89a47b-9dd5-11ef-938f-6e654a286000/Library/Caches/com.apple.xbs/Sources/python3/future-0.18.2-py3-none-any.whl
 importlib_metadata==8.5.0
 iniconfig==2.0.0
 itsdangerous==2.2.0
 Jinja2==3.1.4
-macholib @ file:///AppleInternal/Library/BuildRoots/2c89a47b-9dd5-11ef-938f-6e654a286000/Library/Caches/com.apple.xbs/Sources/python3/macholib-1.15.2-py2.py3-none-any.whl
+# macholib @ file:///AppleInternal/Library/BuildRoots/2c89a47b-9dd5-11ef-938f-6e654a286000/Library/Caches/com.apple.xbs/Sources/python3/macholib-1.15.2-py2.py3-none-any.whl
 MarkupSafe==3.0.2
 packaging==24.2
 pluggy==1.5.0
 pytest==8.3.4
 pytest-flask==1.3.0
-six @ file:///AppleInternal/Library/BuildRoots/2c89a47b-9dd5-11ef-938f-6e654a286000/Library/Caches/com.apple.xbs/Sources/python3/six-1.15.0-py2.py3-none-any.whl
+# six @ file:///AppleInternal/Library/BuildRoots/2c89a47b-9dd5-11ef-938f-6e654a286000/Library/Caches/com.apple.xbs/Sources/python3/six-1.15.0-py2.py3-none-any.whl
 tomli==2.2.1
 Werkzeug==3.1.3
 zipp==3.21.0


### PR DESCRIPTION
Problem:
             Since in ContainersPanel.tsx file we are using “useEffect(() =>“ and we have an empty dependency array being passed with it, this causes it to call the uploadManifest “GET”twice due to React’s “strict mode” feature to help detect bugs. Therefore the balance function was being called twice. 

Solution:
The work around I implemented for this was that I tracked when the last GET request happens and if it happened within the last 2 seconds, I wouldn’t call the balance function. This causes only the first request to trigger the balance operation and logging. 

I tested it and it worked.